### PR TITLE
Fix/make value attributes private

### DIFF
--- a/PEPit/constraint.py
+++ b/PEPit/constraint.py
@@ -9,8 +9,10 @@ class Constraint(object):
     Attributes:
         expression (Expression): The :class:`Expression` that is compared to 0.
         equality_or_inequality (str): "equality" or "inequality". Encodes the type of constraint.
-        dual_variable_value (float): the associated dual variable from the numerical solution to the corresponding PEP.
-                                     Set to None before the call to `PEP.solve` from the :class:`PEP`
+        _value (float): numerical value of self.expression obtained after solving the PEP via SDP solver.
+                        Set to None before the call to the method `PEP.solve` from the :class:`PEP`.
+        _dual_variable_value (float): the associated dual variable from the numerical solution to the corresponding PEP.
+                                      Set to None before the call to `PEP.solve` from the :class:`PEP`
         counter (int): counts the number of :class:`Constraint` objects.
 
     A :class:`Constraint` results from a comparison between two :class:`Expression` objects.
@@ -62,6 +64,54 @@ class Constraint(object):
         assert equality_or_inequality in {'equality', 'inequality'}
         self.equality_or_inequality = equality_or_inequality
 
-        # After solving the PEP, one can find the value of the underlying expression in self.expression.value.
-        # Moreover, the associated dual variable value must be stored in self.dual_variable_value.
-        self.dual_variable_value = None
+        # The value of the underlying expression must be stored in self._value.
+        self._value = None
+
+        # Moreover, the associated dual variable value must be stored in self._dual_variable_value.
+        self._dual_variable_value = None
+
+    def eval(self):
+        """
+        Compute, store and return the value of the underlying :class:`Expression` of this :class:`Constraint`.
+
+        Returns:
+            self._value (np.array): The value of the underlying :class:`Expression` of this :class:`Constraint`
+                                    after the corresponding PEP was solved numerically.
+
+        Raises:
+            ValueError("The PEP must be solved to evaluate Constraints!") if the PEP has not been solved yet.
+
+        """
+
+        # If the attribute value is not None, then simply return it.
+        # Otherwise, compute it and return it.
+        if self._value is None:
+
+            try:
+                self._value = self.expression.eval()
+            except ValueError("The PEP must be solved to evaluate Expressions!"):
+                raise ValueError("The PEP must be solved to evaluate Constraints!")
+
+        return self._value
+
+    def eval_dual(self):
+        """
+        Compute, store and return the value of the dual variable of this :class:`Constraint`.
+
+        Returns:
+            self._dual_variable_value (float): The value of the dual variable of this :class:`Constraint`
+                                               after the corresponding PEP was solved numerically.
+
+        Raises:
+            ValueError("The PEP must be solved to evaluate Constraints dual variables!")
+            if the PEP has not been solved yet.
+
+        """
+
+        # If the attribute _dual_variable_value is not None, then simply return it.
+        # Otherwise, raise a ValueError.
+        if self._dual_variable_value is None:
+            # The PEP would have filled the attribute at the end of the solve.
+            raise ValueError("The PEP must be solved to evaluate Constraints dual variables!")
+
+        return self._dual_variable_value

--- a/PEPit/expression.py
+++ b/PEPit/expression.py
@@ -79,7 +79,7 @@ class Expression(object):
         self._is_leaf = is_leaf
 
         # Initialize the value attribute to None until the PEP is solved
-        self.value = None
+        self._value = None
 
         # If leaf function value, the decomposition is updated,
         # the object counter is set
@@ -330,7 +330,7 @@ class Expression(object):
 
         # If the attribute value is not None, then simply return it.
         # Otherwise, compute it and return it.
-        if self.value is None:
+        if self._value is None:
             # If leaf function value, the PEP would have filled the attribute at the end of the solve.
             if self._is_leaf:
                 raise ValueError("The PEP must be solved to evaluate Points!")
@@ -356,7 +356,7 @@ class Expression(object):
                         raise TypeError("Expressions are made of function values, inner products and constants only!"
                                         "Got {}".format(type(key)))
                 # Store the value
-                self.value = value
+                self._value = value
 
         # Return the value
-        return self.value
+        return self._value

--- a/PEPit/expression.py
+++ b/PEPit/expression.py
@@ -322,7 +322,7 @@ class Expression(object):
             self._value (np.array): Value of this :class:`Expression` after the corresponding PEP was solved numerically.
 
         Raises:
-            ValueError("The PEP must be solved to evaluate Points!") if the PEP has not been solved yet.
+            ValueError("The PEP must be solved to evaluate Expressions!") if the PEP has not been solved yet.
 
             TypeError("Expressions are made of function values, inner products and constants only!")
 
@@ -333,7 +333,7 @@ class Expression(object):
         if self._value is None:
             # If leaf function value, the PEP would have filled the attribute at the end of the solve.
             if self._is_leaf:
-                raise ValueError("The PEP must be solved to evaluate Points!")
+                raise ValueError("The PEP must be solved to evaluate Expressions!")
             # If linear combination,
             # combine the values of the leaf expressions,
             # and store the result before returning it.

--- a/PEPit/expression.py
+++ b/PEPit/expression.py
@@ -17,8 +17,8 @@ class Expression(object):
         _is_leaf (bool): True if self is a function value defined from scratch
                                    (not as linear combination of other function values).
                                    False if self is a linear combination of existing :class:`Expression` objects.
-        value (float): numerical value of self obtained after solving the PEP via SDP solver.
-                          Set to None before the call to the method `PEP.solve` from the :class:`PEP`.
+        _value (float): numerical value of self obtained after solving the PEP via SDP solver.
+                        Set to None before the call to the method `PEP.solve` from the :class:`PEP`.
         decomposition_dict (dict): decomposition of self as a linear combination of **leaf** :class:`Expression` objects.
                                    Keys are :class:`Expression` objects or tuple of 2 :class:`Point` objects.
                                    And values are their associated coefficients.
@@ -319,7 +319,7 @@ class Expression(object):
         Compute, store and return the value of this :class:`Expression`.
 
         Returns:
-            self.value (np.array): Value of this :class:`Expression` after the corresponding PEP was solved numerically.
+            self._value (np.array): Value of this :class:`Expression` after the corresponding PEP was solved numerically.
 
         Raises:
             ValueError("The PEP must be solved to evaluate Points!") if the PEP has not been solved yet.

--- a/PEPit/pep.py
+++ b/PEPit/pep.py
@@ -181,7 +181,7 @@ class PEP(object):
             solver (str or None): The name of the underlying solver.
             verbose (int): Level of information details to print (0 or 1)
             tracetrick (bool): Apply trace heuristic as a proxy for minimizing
-             the dimension of the solution (rank of the Gram matrix).
+                               the dimension of the solution (rank of the Gram matrix).
             return_full_cvxpy_problem (bool): If True, return the cvxpy Problem object.
                                               If False, return the worst case value only.
                                               Set to False by default.
@@ -357,7 +357,8 @@ class PEP(object):
             cvx_constraints (list): a list of cvxpy formatted constraints.
 
         Returns:
-             np.float: the position, in the list of performance metric, of the one that is actually reached.
+             position_of_minimal_objective (np.float): the position, in the list of performance metric,
+                                                       of the one that is actually reached.
 
         """
 

--- a/PEPit/pep.py
+++ b/PEPit/pep.py
@@ -337,17 +337,17 @@ class PEP(object):
         # Note the other ones are not stored until user asks to eval them
         for point in self.list_of_points:
             if point.get_is_leaf():
-                point.value = points_values[:, point.counter]
+                point._value = points_values[:, point.counter]
         for function in self.list_of_functions:
             if function.get_is_leaf():
                 for triplet in function.list_of_points:
                     point, gradient, function_value = triplet
                     if point.get_is_leaf():
-                        point.value = points_values[:, point.counter]
+                        point._value = points_values[:, point.counter]
                     if gradient.get_is_leaf():
-                        gradient.value = points_values[:, gradient.counter]
+                        gradient._value = points_values[:, gradient.counter]
                     if function_value.get_is_leaf():
-                        function_value.value = F_value[function_value.counter]
+                        function_value._value = F_value[function_value.counter]
 
     def _eval_constraint_dual_values(self, cvx_constraints):
         """

--- a/PEPit/pep.py
+++ b/PEPit/pep.py
@@ -374,13 +374,13 @@ class PEP(object):
 
         # Store all dual values of initial conditions (Generally the rate)
         for condition in self.list_of_conditions:
-            condition.dual_variable_value = cvx_constraints[counter].dual_value
+            condition._dual_variable_value = cvx_constraints[counter].dual_value
             counter += 1
 
         # Store all the class constraints dual values, providing the proof of the desired rate.
         for function in self.list_of_functions:
             for constraint in function.list_of_constraints:
-                constraint.dual_variable_value = cvx_constraints[counter].dual_value
+                constraint._dual_variable_value = cvx_constraints[counter].dual_value
                 counter += 1
 
         # Return the position of the reached performance metric

--- a/PEPit/point.py
+++ b/PEPit/point.py
@@ -13,8 +13,8 @@ class Point(object):
         _is_leaf (bool): True if self is defined from scratch
                          (not as linear combination of other :class:`Point` objects).
                          False if self is defined as linear combination of other points.
-        value (nd.array): numerical value of self obtained after solving the PEP via SDP solver.
-                          Set to None before the call to the method `PEP.solve` from the :class:`PEP`.
+        _value (nd.array): numerical value of self obtained after solving the PEP via SDP solver.
+                           Set to None before the call to the method `PEP.solve` from the :class:`PEP`.
         decomposition_dict (dict): decomposition of self as a linear combination of leaf :class:`Point` objects.
                                    Keys are :class:`Point` objects.
                                    And values are their associated coefficients.
@@ -257,7 +257,7 @@ class Point(object):
         Compute, store and return the value of this :class:`Point`.
 
         Returns:
-            self.value (np.array): The value of this :class:`Point` after the corresponding PEP was solved numerically.
+            self._value (np.array): The value of this :class:`Point` after the corresponding PEP was solved numerically.
 
         Raises:
             ValueError("The PEP must be solved to evaluate Points!") if the PEP has not been solved yet.

--- a/PEPit/point.py
+++ b/PEPit/point.py
@@ -272,7 +272,7 @@ class Point(object):
                 raise ValueError("The PEP must be solved to evaluate Points!")
             # If linear combination, combine the values of the leaf, and store the result before returning it.
             else:
-                value = 0
+                value = np.zeros(Point.counter)
                 for point, weight in self.decomposition_dict.items():
                     value += weight * point.eval()
                 self._value = value

--- a/PEPit/point.py
+++ b/PEPit/point.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from PEPit.expression import Expression
 
 from PEPit.tools.dict_operations import merge_dict, prune_dict, multiply_dicts
@@ -81,7 +83,7 @@ class Point(object):
         self._is_leaf = is_leaf
 
         # Initialize the value attribute to None until the PEP is solved
-        self.value = None
+        self._value = None
 
         # If leaf, the decomposition is updated w.r.t the new direction,
         # the object counter is set
@@ -264,7 +266,7 @@ class Point(object):
 
         # If the attribute value is not None, then simply return it.
         # Otherwise, compute it and return it.
-        if self.value is None:
+        if self._value is None:
             # If leaf, the PEP would have filled the attribute at the end of the solve.
             if self._is_leaf:
                 raise ValueError("The PEP must be solved to evaluate Points!")
@@ -273,6 +275,6 @@ class Point(object):
                 value = 0
                 for point, weight in self.decomposition_dict.items():
                     value += weight * point.eval()
-                self.value = value
+                self._value = value
 
-        return self.value
+        return self._value

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -80,13 +80,21 @@ class TestConstraints(unittest.TestCase):
             self.assertIsInstance(self.problem.list_of_conditions[i].equality_or_inequality, str)
             self.assertIn(self.problem.list_of_conditions[i].equality_or_inequality, {'equality', 'inequality'})
 
-    def test_dual_variable_value(self):
+    def test_eval(self):
 
         for i in range(len(self.func.list_of_constraints)):
-            self.assertIsInstance(self.func.list_of_constraints[i].dual_variable_value, float)
+            self.assertIsInstance(self.func.list_of_constraints[i].eval(), float)
 
         for i in range(len(self.problem.list_of_conditions)):
-            self.assertIsInstance(self.problem.list_of_conditions[i].dual_variable_value, float)
+            self.assertIsInstance(self.problem.list_of_conditions[i].eval(), float)
+
+    def test_eval_dual(self):
+
+        for i in range(len(self.func.list_of_constraints)):
+            self.assertIsInstance(self.func.list_of_constraints[i].eval_dual(), float)
+
+        for i in range(len(self.problem.list_of_conditions)):
+            self.assertIsInstance(self.problem.list_of_conditions[i].eval_dual(), float)
 
     def tearDown(self):
 

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -60,11 +60,11 @@ class TestPEP(unittest.TestCase):
             point, gradient, function_value = triplet
 
             if point.get_is_leaf():
-                self.assertIsNot(point.value, None)
+                self.assertIsNot(point._value, None)
             if gradient.get_is_leaf():
-                self.assertIsNot(gradient.value, None)
+                self.assertIsNot(gradient._value, None)
             if function_value.get_is_leaf():
-                self.assertIsNot(function_value.value, None)
+                self.assertIsNot(function_value._value, None)
 
     def test_eval_constraint_dual_values(self):
 

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy as np
 
 from PEPit.pep import PEP
 from PEPit.point import Point
@@ -59,12 +60,9 @@ class TestPEP(unittest.TestCase):
 
             point, gradient, function_value = triplet
 
-            if point.get_is_leaf():
-                self.assertIsNot(point._value, None)
-            if gradient.get_is_leaf():
-                self.assertIsNot(gradient._value, None)
-            if function_value.get_is_leaf():
-                self.assertIsNot(function_value._value, None)
+            self.assertIsInstance(point.eval(), np.ndarray)
+            self.assertIsInstance(gradient.eval(), np.ndarray)
+            self.assertIsInstance(function_value.eval(), float)
 
     def test_eval_constraint_dual_values(self):
 

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -71,12 +71,12 @@ class TestPEP(unittest.TestCase):
         self.assertAlmostEqual(pepit_tau, theoretical_tau, delta=theoretical_tau * 10 ** -3)
 
         for condition in self.problem.list_of_conditions:
-            self.assertIsInstance(condition.dual_variable_value, float)
-            self.assertAlmostEqual(condition.dual_variable_value, pepit_tau, delta=pepit_tau * 10 ** -3)
+            self.assertIsInstance(condition._dual_variable_value, float)
+            self.assertAlmostEqual(condition._dual_variable_value, pepit_tau, delta=pepit_tau * 10 ** -3)
 
         for constraint in self.func.list_of_constraints:
-            self.assertIsInstance(constraint.dual_variable_value, float)
-            self.assertAlmostEqual(constraint.dual_variable_value,
+            self.assertIsInstance(constraint._dual_variable_value, float)
+            self.assertAlmostEqual(constraint._dual_variable_value,
                                    2 * self.gamma * max(abs(1 - self.mu * self.gamma), abs(1 - self.L * self.gamma)),
                                    delta=2 * self.gamma * 10 ** 3)
 


### PR DESCRIPTION
Protect "value" and "dual_variable_value" attributes that can be obtained with eval() and eval_dual() methods.
This PR also contains some small fixes mostly in docstring and uniformization of gradient._value type.